### PR TITLE
Add --reference_image and --driving_video CLI arguments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+Issue to solve: https://github.com/andchir/PersonaLive/issues/6
+Your prepared branch: issue-6-ccf22ac4023f
+Your prepared working directory: /tmp/gh-issue-solver-1766320504809
+Your forked repository: konard/andchir-PersonaLive
+Original repository (upstream): andchir/PersonaLive
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/andchir/PersonaLive/issues/6
-Your prepared branch: issue-6-ccf22ac4023f
-Your prepared working directory: /tmp/gh-issue-solver-1766320504809
-Your forked repository: konard/andchir-PersonaLive
-Original repository (upstream): andchir/PersonaLive
-
-Proceed.

--- a/inference_offline.py
+++ b/inference_offline.py
@@ -48,6 +48,10 @@ def parse_args():
                         help="Number of frames to process per batch. Set to 0 to process all frames at once (default). "
                              "Use smaller values (e.g., 16, 32) to reduce VRAM usage on GPUs with limited memory. "
                              "Must be divisible by 4 (temporal_window_size).")
+    parser.add_argument("--reference_image", type=str, default='',
+                        help="Path to reference image. If provided, overrides test_cases from config file.")
+    parser.add_argument("--driving_video", type=str, default='',
+                        help="Path to driving video. If provided, overrides test_cases from config file.")
     args = parser.parse_args()
 
     return args
@@ -175,7 +179,11 @@ def main(args):
         [transforms.Resize((height, width)), transforms.ToTensor()]
     )
 
-    args.test_cases = OmegaConf.load(args.config)["test_cases"]
+    # Override test_cases from config if CLI arguments are provided
+    if args.reference_image and args.driving_video:
+        args.test_cases = {args.reference_image: [args.driving_video]}
+    else:
+        args.test_cases = OmegaConf.load(args.config)["test_cases"]
 
     for ref_image_path in list(args.test_cases.keys()):
         for pose_video_path in args.test_cases[ref_image_path]:


### PR DESCRIPTION
## Summary
- Added `--reference_image` and `--driving_video` command-line arguments to `inference_offline.py`
- When both arguments are provided, they override the `test_cases` from the configuration file
- By default, both arguments are empty and the behavior remains unchanged (uses config file)

## Usage

```bash
# Original usage (from config file)
python inference_offline.py --config configs/prompts/personalive_offline.yaml

# New usage with CLI arguments (overrides config)
python inference_offline.py --reference_image path/to/image.png --driving_video path/to/video.mp4
```

## Test plan
- [x] Verified that the arguments are properly added to argparse
- [x] Verified that when both arguments are provided, they override test_cases from config
- [x] Verified that when arguments are empty (default), test_cases from config are used

Fixes andchir/PersonaLive#6

🤖 Generated with [Claude Code](https://claude.com/claude-code)