### PR TITLE
Add --reference_image and --driving_video CLI parameters

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/andchir/PersonaLive/issues/23
-Your prepared branch: issue-23-fe06a9725b5c
-Your prepared working directory: /tmp/gh-issue-solver-1766497064090
-Your forked repository: konard/andchir-PersonaLive
-Original repository (upstream): andchir/PersonaLive
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+Issue to solve: https://github.com/andchir/PersonaLive/issues/23
+Your prepared branch: issue-23-fe06a9725b5c
+Your prepared working directory: /tmp/gh-issue-solver-1766497064090
+Your forked repository: konard/andchir-PersonaLive
+Original repository (upstream): andchir/PersonaLive
+
+Proceed.

--- a/inference_offline.py
+++ b/inference_offline.py
@@ -37,6 +37,8 @@ def parse_args():
     parser.add_argument("--device", type=str, default="cuda")
     parser.add_argument("--use_xformers", type=bool, default=True)
     parser.add_argument("--stream_gen", type=bool, default=True, help='use streaming generation strategy to reduce VRAM usage.')
+    parser.add_argument("--reference_image", type=str, default='', help='Path to reference image. If provided, overrides test_cases from config.')
+    parser.add_argument("--driving_video", type=str, default='', help='Path to driving video. If provided, overrides test_cases from config.')
     args = parser.parse_args()
 
     return args
@@ -169,7 +171,10 @@ def main(args):
         [transforms.Resize((height, width)), transforms.ToTensor()]
     )
 
-    args.test_cases = OmegaConf.load(args.config)["test_cases"]
+    if args.reference_image and args.driving_video:
+        args.test_cases = {args.reference_image: [args.driving_video]}
+    else:
+        args.test_cases = OmegaConf.load(args.config)["test_cases"]
 
     for ref_image_path in list(args.test_cases.keys()):
         for pose_video_path in args.test_cases[ref_image_path]:


### PR DESCRIPTION
## Summary
- Added `--reference_image` CLI parameter to specify the path to a reference image
- Added `--driving_video` CLI parameter to specify the path to a driving video  
- When both parameters are provided, they override the `test_cases` from the configuration file
- Default values are empty strings, preserving backward compatibility

## Usage

With new parameters (overrides config file):
```bash
python inference_offline.py --reference_image path/to/image.png --driving_video path/to/video.mp4
```

Without new parameters (uses config file as before):
```bash
python inference_offline.py
```

## Test plan
- [x] Verify Python syntax is correct
- [ ] Test with `--reference_image` and `--driving_video` parameters  
- [ ] Verify config file is used when parameters are not provided
- [ ] Verify parameters override config file when provided

Fixes andchir/PersonaLive#23

🤖 Generated with [Claude Code](https://claude.com/claude-code)